### PR TITLE
Fixed error in calculating stopping cross section

### DIFF
--- a/src/run_transportCS.m
+++ b/src/run_transportCS.m
@@ -53,7 +53,7 @@ function run_transportCS(filepath,datafilepath)
             end
             difcs(j) = numdiffusioncs(bvals,th);
             visccs(j) = numvisccs(bvals,th);
-            stoppingcs(j) = numstoppingcs(Evals(j),m1,m2,diffusioncs(j));
+            stoppingcs(j) = numstoppingcs(Evals(j),m1,m2,difcs(j));
             totalcs(j) = numtotalcs(th_c,bvals,th);
         end
         CMtoLab = (m1+m2)/m2;


### PR DESCRIPTION
Name of diffusion CS array was not updated when repo was reorganized, which led to stopping CS being calculated with incorrect data. Typo has now been fixed and data is consistent with SRIM results. 